### PR TITLE
Bring rustfmt up to speed with current version of Rust

### DIFF
--- a/src/format.rs
+++ b/src/format.rs
@@ -228,7 +228,7 @@ pub struct Formatter<'a> {
     newline_after_comma: bool,
     newline_after_brace: bool,
     in_attribute: bool,
-    output: &'a mut Writer+'a
+    output: &'a mut (Writer + 'a)
 }
 
 impl<'a> Formatter<'a> {

--- a/src/format.rs
+++ b/src/format.rs
@@ -27,7 +27,8 @@ use syntax::parse::token::Token;
 use syntax::parse::token::keywords;
 use syntax::parse::token;
 
-use token::{Comment, LexerVal, TransformedToken, BlankLine};
+use token::TransformedToken;
+use token::TransformedToken::{Comment,LexerVal,BlankLine};
 
 macro_rules! try_io(
     ($e:expr) => (match $e {

--- a/src/format.rs
+++ b/src/format.rs
@@ -94,52 +94,52 @@ impl LineToken {
             _ => (Token::Whitespace, false)
         };
         match (&curr_tok, &next_tok) {
-            (&Token::Ident(..), &Token::Ident(..)) => true,
-            (&Token::Ident(..), &Token::Not)
+            (&token::Ident(..), &token::Ident(..)) => true,
+            (&token::Ident(..), &token::Not)
                     if !curr_tok.is_any_keyword() => {
                 // Macros.
                 false
             }
 
-            (&Token::Ident(..), _) if
+            (&token::Ident(..), _) if
 		    curr_tok.is_keyword(keywords::If) ||
 		    curr_tok.is_keyword(keywords::As) ||
 		    curr_tok.is_keyword(keywords::Match) => {
                 true
             }
-            (_, &Token::Ident(..))
+            (_, &token::Ident(..))
 		    if next_tok.is_keyword(keywords::If) => {
                 true
             }
 
-            (&Token::Colon, _) => true,
-            (&Token::Comma, _) => true,
-            (&Token::Eq, _) | (_, &Token::Eq) => true,
-            (&Token::Lt, _) | (_, &Token::Lt) => true,
-            (&Token::Le, _) | (_, &Token::Le) => true,
-            (&Token::EqEq, _) | (_, &Token::EqEq) => true,
-            (&Token::Ne, _) | (_, &Token::Ne) => true,
-            (&Token::Ge, _) | (_, &Token::Ge) => true,
-            (&Token::Gt, _) | (_, &Token::Gt) => true,
-            (&Token::AndAnd, _) | (_, &Token::AndAnd) => true,
-            (&Token::OrOr, _) | (_, &Token::OrOr) => true,
-            (&Token::Tilde, _) | (_, &Token::Tilde) => true,
+            (&token::Colon, _) => true,
+            (&token::Comma, _) => true,
+            (&token::Eq, _) | (_, &token::Eq) => true,
+            (&token::Lt, _) | (_, &token::Lt) => true,
+            (&token::Le, _) | (_, &token::Le) => true,
+            (&token::EqEq, _) | (_, &token::EqEq) => true,
+            (&token::Ne, _) | (_, &token::Ne) => true,
+            (&token::Ge, _) | (_, &token::Ge) => true,
+            (&token::Gt, _) | (_, &token::Gt) => true,
+            (&token::AndAnd, _) | (_, &token::AndAnd) => true,
+            (&token::OrOr, _) | (_, &token::OrOr) => true,
+            (&token::Tilde, _) | (_, &token::Tilde) => true,
 
-            (&Token::OpenDelim(DelimToken::Paren), _) => false,
-            (_, &Token::CloseDelim(DelimToken::Paren)) => false,
-            (&Token::BinOp(BinOpToken::And), _) => false,
+            (&token::OpenDelim(DelimToken::Paren), _) => false,
+            (_, &token::CloseDelim(DelimToken::Paren)) => false,
+            (&token::BinOp(BinOpToken::And), _) => false,
 
-            (&Token::BinOp(_), _) | (_, &Token::BinOp(_)) => true,
-            (&Token::BinOpEq(_), _) | (_, &Token::BinOpEq(_)) => true,
+            (&token::BinOp(_), _) | (_, &token::BinOp(_)) => true,
+            (&token::BinOpEq(_), _) | (_, &token::BinOpEq(_)) => true,
 
-            (&Token::ModSep, _) | (_, &Token::ModSep) => false,
+            (&token::ModSep, _) | (_, &token::ModSep) => false,
 
-            (&Token::RArrow, _) | (_, &Token::RArrow) => true,
-            (&Token::FatArrow, _) | (_, &Token::FatArrow) => true,
-            (&Token::OpenDelim(DelimToken::Brace), _) | (_, &Token::OpenDelim(DelimToken::Brace)) => true,
-            (&Token::CloseDelim(DelimToken::Brace), _) | (_, &Token::CloseDelim(DelimToken::Brace)) => true,
-            (&Token::Semi, _) | (_, &Token::Comment) => true,
-            (&Token::Comment, _) => true,
+            (&token::RArrow, _) | (_, &token::RArrow) => true,
+            (&token::FatArrow, _) | (_, &token::FatArrow) => true,
+            (&token::OpenDelim(DelimToken::Brace), _) | (_, &token::OpenDelim(DelimToken::Brace)) => true,
+            (&token::CloseDelim(DelimToken::Brace), _) | (_, &token::CloseDelim(DelimToken::Brace)) => true,
+            (&token::Semi, _) | (_, &token::Comment) => true,
+            (&token::Comment, _) => true,
             _ => false,
         }
     }
@@ -156,7 +156,7 @@ impl LineToken {
         match &self.tok {
             &LexerVal(ref token_and_span) => {
                 match &token_and_span.tok {
-                    &Token::CloseDelim(DelimToken::Brace) => -TAB_WIDTH,
+                    &token::CloseDelim(DelimToken::Brace) => -TAB_WIDTH,
                     _ => 0,
                 }
             },
@@ -208,7 +208,7 @@ impl LogicalLine {
                 match &line_token.tok {
                     &LexerVal(ref token_and_span) => {
                         match token_and_span.tok {
-                            Token::OpenDelim(DelimToken::Brace) => TAB_WIDTH,
+                            token::OpenDelim(DelimToken::Brace) => TAB_WIDTH,
                             _ => 0,
                         }
                     },
@@ -239,8 +239,8 @@ impl<'a> Formatter<'a> {
             curr_idx: 0,
             indent: 0,
             logical_line: LogicalLine::new(),
-            last_token: Token::Semi,
-            second_previous_token: Token::Semi,
+            last_token: token::Semi,
+            second_previous_token: token::Semi,
             newline_after_comma: false,
             newline_after_brace: true,
             in_attribute: false,
@@ -275,25 +275,25 @@ impl<'a> Formatter<'a> {
         match &line_token.tok {
             &LexerVal(ref token_and_span) => {
                 match token_and_span.tok {
-                    Token::Semi => {
+                    token::Semi => {
                         match self.curr_tok() {
                             &Comment(_, starts_line, _) => starts_line,
                             _ => true
                         }
                     },
-                    Token::CloseDelim(DelimToken::Brace) => {
+                    token::CloseDelim(DelimToken::Brace) => {
                         match self.curr_tok() {
-                            &LexerVal(TokenAndSpan { tok: Token::Comma, sp: _ }) => {
+                            &LexerVal(TokenAndSpan { tok: token::Comma, sp: _ }) => {
                                 false
                             }
                             _ => true
                         }
                     },
-                    Token::Comma => self.newline_after_comma,
-                    Token::OpenDelim(DelimToken::Brace) => {
+                    token::Comma => self.newline_after_comma,
+                    token::OpenDelim(DelimToken::Brace) => {
                         match self.curr_tok() {
                             &LexerVal(ref t) => {
-                                if t.tok == Token::CloseDelim(DelimToken::Brace) {
+                                if t.tok == token::CloseDelim(DelimToken::Brace) {
                                     false
                                 } else {
                                     self.newline_after_brace
@@ -302,8 +302,8 @@ impl<'a> Formatter<'a> {
                             _ => self.newline_after_brace
                         }
                     },
-                    Token::DocComment(_) => true,
-                    Token::CloseDelim(DelimToken::Bracket) => self.in_attribute,
+                    token::DocComment(_) => true,
+                    token::CloseDelim(DelimToken::Bracket) => self.in_attribute,
                     _ => false,
                 }
             },
@@ -316,9 +316,9 @@ impl<'a> Formatter<'a> {
         match &line_token.tok {
             &LexerVal(ref token_and_span) => {
                 match token_and_span.tok {
-                    Token::CloseDelim(DelimToken::Brace) => {
+                    token::CloseDelim(DelimToken::Brace) => {
                         match (&self.second_previous_token, &self.last_token) {
-                            (&Token::FatArrow, &Token::OpenDelim(DelimToken::Brace)) => false,
+                            (&token::FatArrow, &token::OpenDelim(DelimToken::Brace)) => false,
                             _ => self.newline_after_brace
                         }
                     },
@@ -351,14 +351,14 @@ impl<'a> Formatter<'a> {
 
     fn parse_match(&mut self) -> FormatterResult<bool> {
         // We've already parsed the keyword. Parse until we find a `{`.
-        if !try!(self.parse_tokens_up_to(|token| *token == Token::OpenDelim(DelimToken::Brace))) {
+        if !try!(self.parse_tokens_up_to(|token| *token == token::OpenDelim(DelimToken::Brace))) {
             return Ok(false);
         }
 
         let old_newline_after_comma_setting = self.newline_after_comma;
         self.newline_after_comma = true;
 
-        if !try!(self.parse_productions_up_to(|token| *token == Token::CloseDelim(DelimToken::Brace))) {
+        if !try!(self.parse_productions_up_to(|token| *token == token::CloseDelim(DelimToken::Brace))) {
             return Ok(false);
         }
 
@@ -371,15 +371,15 @@ impl<'a> Formatter<'a> {
         self.newline_after_brace = false;
 
         // We've already parsed the keyword. Parse until we find a `{`.
-        if !try!(self.parse_tokens_up_to(|token| *token == Token::OpenDelim(DelimToken::Brace) || *token == Token::Semi)) {
+        if !try!(self.parse_tokens_up_to(|token| *token == token::OpenDelim(DelimToken::Brace) || *token == token::Semi)) {
             return Ok(false);
         }
 
-        if self.last_token == Token::OpenDelim(DelimToken::Brace) {
+        if self.last_token == token::OpenDelim(DelimToken::Brace) {
             let old_newline_after_comma_setting = self.newline_after_comma;
             self.newline_after_comma = false;
 
-            if !try!(self.parse_productions_up_to(|token| *token == Token::CloseDelim(DelimToken::Brace))) {
+            if !try!(self.parse_productions_up_to(|token| *token == token::CloseDelim(DelimToken::Brace))) {
                 return Ok(false);
             }
 
@@ -394,7 +394,7 @@ impl<'a> Formatter<'a> {
         let old_newline_after_comma_setting = self.newline_after_comma;
         self.newline_after_comma = true;
         // We've already parsed the '{'. Parse until we find a '}'.
-        let result = try!(self.parse_productions_up_to(|token| *token == Token::CloseDelim(DelimToken::Brace)));
+        let result = try!(self.parse_productions_up_to(|token| *token == token::CloseDelim(DelimToken::Brace)));
 
         self.newline_after_comma = old_newline_after_comma_setting;
         return Ok(result);
@@ -405,7 +405,7 @@ impl<'a> Formatter<'a> {
         self.newline_after_comma = false;
 
         // We've already parsed the '('. Parse until we find a ')'.
-        let result = try!(self.parse_productions_up_to(|token| *token == Token::CloseDelim(DelimToken::Paren)));
+        let result = try!(self.parse_productions_up_to(|token| *token == token::CloseDelim(DelimToken::Paren)));
 
         self.newline_after_comma = old_newline_after_comma_setting;
         return Ok(result);
@@ -414,7 +414,7 @@ impl<'a> Formatter<'a> {
     fn parse_attribute(&mut self) -> FormatterResult<bool> {
         // Parse until we find a ']'.
         self.in_attribute = true;
-        let result = try!(self.parse_productions_up_to(|token| *token == Token::CloseDelim(DelimToken::Bracket)));
+        let result = try!(self.parse_productions_up_to(|token| *token == token::CloseDelim(DelimToken::Bracket)));
         return Ok(result);
     }
 
@@ -422,15 +422,15 @@ impl<'a> Formatter<'a> {
         let production_to_parse;
         // TRANSFORM
         match self.last_token {
-            Token::Ident(..) if self.last_token.is_keyword(keywords::Match) => {
+            token::Ident(..) if self.last_token.is_keyword(keywords::Match) => {
                 production_to_parse = MatchProduction;
             }
-            Token::Ident(..) if self.last_token.is_keyword(keywords::Use) => {
+            token::Ident(..) if self.last_token.is_keyword(keywords::Use) => {
                 production_to_parse = UseProduction;
             }
-            Token::OpenDelim(DelimToken::Brace) => production_to_parse = BracesProduction,
-            Token::OpenDelim(DelimToken::Paren) => production_to_parse = ParenthesesProduction,
-            Token::Pound => production_to_parse = AttributeProduction,
+            token::OpenDelim(DelimToken::Brace) => production_to_parse = BracesProduction,
+            token::OpenDelim(DelimToken::Paren) => production_to_parse = ParenthesesProduction,
+            token::Pound => production_to_parse = AttributeProduction,
             _ => return Ok(true),
         }
 
@@ -467,8 +467,8 @@ impl<'a> Formatter<'a> {
             self.second_previous_token = self.last_token.clone();
             self.last_token = match curr_tok_copy {
                 LexerVal(token_and_span) => token_and_span.tok,
-                BlankLine => Token::Whitespace,
-                Comment(_, _, _) => Token::Comment
+                BlankLine => token::Whitespace,
+                Comment(_, _, _) => token::Comment
             };
             self.logical_line.tokens.push(current_line_token);
             if token_ends_logical_line {
@@ -495,13 +495,13 @@ impl<'a> Formatter<'a> {
                     try_io!(self.output.write_str(format!("{}", pprust::token_to_string(curr_tok)).as_slice()));
 
                     // collapse empty blocks in match arms
-                    if (curr_tok == &Token::OpenDelim(DelimToken::Brace) && i != self.logical_line.tokens.len() - 1) &&
-                        self.logical_line.tokens[i+1].is_token(&Token::CloseDelim(DelimToken::Brace)) {
+                    if (curr_tok == &token::OpenDelim(DelimToken::Brace) && i != self.logical_line.tokens.len() - 1) &&
+                        self.logical_line.tokens[i+1].is_token(&token::CloseDelim(DelimToken::Brace)) {
                         continue;
                     }
                     // no whitespace after right-brackets, before comma in match arm
-                    if (curr_tok == &Token::CloseDelim(DelimToken::Brace) && i != self.logical_line.tokens.len() - 1) &&
-                        self.logical_line.tokens[i+1].is_token(&Token::Comma) {
+                    if (curr_tok == &token::CloseDelim(DelimToken::Brace) && i != self.logical_line.tokens.len() - 1) &&
+                        self.logical_line.tokens[i+1].is_token(&token::Comma) {
                         continue;
                     }
                     for _ in range(0, self.logical_line.whitespace_after(i)) {

--- a/src/format.rs
+++ b/src/format.rs
@@ -246,12 +246,12 @@ impl<'a> Formatter<'a> {
             match self.next_token() {
                 Ok(true) => {
                     match self.parse_production() {
-                        Err(e) => fail!(e),
+                        Err(e) => panic!(e),
                         _ => {}
                     }
                 },
                 Ok(false) => break,
-                Err(e) => fail!(e)
+                Err(e) => panic!(e)
             }
         }
     }

--- a/src/format.rs
+++ b/src/format.rs
@@ -182,7 +182,7 @@ impl LogicalLine {
         }
 
         for i in range(0, self.tokens.len()) {
-            self.tokens.get_mut(i).x_pos = x_pos;
+            self.tokens.get_mut(i).unwrap().x_pos = x_pos;
             x_pos += self.tokens[i].length();
 
             if i < self.tokens.len() - 1 &&
@@ -229,7 +229,7 @@ pub struct Formatter<'a> {
     newline_after_comma: bool,
     newline_after_brace: bool,
     in_attribute: bool,
-    output: &'a mut Writer
+    output: &'a mut Writer+'a
 }
 
 impl<'a> Formatter<'a> {
@@ -492,7 +492,7 @@ impl<'a> Formatter<'a> {
             match &self.logical_line.tokens[i] {
                 &LineToken{ tok: LexerVal(ref token_and_span), x_pos: _ } => {
                     let curr_tok = &token_and_span.tok;
-                    try_io!(self.output.write_str(format!("{}", curr_tok)));
+                    try_io!(self.output.write_str(format!("{}", curr_tok).as_slice()));
 
                     // collapse empty blocks in match arms
                     if (curr_tok == &Token::OpenDelim(DelimToken::Brace) && i != self.logical_line.tokens.len() - 1) &&

--- a/src/format.rs
+++ b/src/format.rs
@@ -102,13 +102,13 @@ impl LineToken {
             }
 
             (&Token::Ident(..), _) if
-		    curr_tok.is_keyword(keywords::If) ||
-		    curr_tok.is_keyword(keywords::As) ||
-		    curr_tok.is_keyword(keywords::Match) => {
+            curr_tok.is_keyword(keywords::If) ||
+            curr_tok.is_keyword(keywords::As) ||
+            curr_tok.is_keyword(keywords::Match) => {
                 true
             }
             (_, &Token::Ident(..))
-		    if next_tok.is_keyword(keywords::If) => {
+                    if next_tok.is_keyword(keywords::If) => {
                 true
             }
 
@@ -147,7 +147,7 @@ impl LineToken {
     fn length(&self) -> i32 {
         match &self.tok {
             &LexerVal(ref token_and_span) =>
-		pprust::token_to_string(&token_and_span.tok).len() as i32,
+                pprust::token_to_string(&token_and_span.tok).len() as i32,
             _ => 0
         }
     }

--- a/src/format.rs
+++ b/src/format.rs
@@ -28,6 +28,7 @@ use syntax::parse::token::DelimToken;
 use syntax::parse::token::BinOpToken;
 use syntax::parse::token::keywords;
 use syntax::parse::token;
+use syntax::print::pprust;
 
 use token::TransformedToken;
 use token::TransformedToken::{Comment,LexerVal,BlankLine};
@@ -492,7 +493,7 @@ impl<'a> Formatter<'a> {
             match &self.logical_line.tokens[i] {
                 &LineToken{ tok: LexerVal(ref token_and_span), x_pos: _ } => {
                     let curr_tok = &token_and_span.tok;
-                    try_io!(self.output.write_str(format!("{}", curr_tok).as_slice()));
+                    try_io!(self.output.write_str(format!("{}", pprust::token_to_string(curr_tok)).as_slice()));
 
                     // collapse empty blocks in match arms
                     if (curr_tok == &Token::OpenDelim(DelimToken::Brace) && i != self.logical_line.tokens.len() - 1) &&

--- a/src/format.rs
+++ b/src/format.rs
@@ -147,8 +147,7 @@ impl LineToken {
     fn length(&self) -> i32 {
         match &self.tok {
             &LexerVal(ref token_and_span) =>
-		format!("{}", token_and_span.tok).len() as i32,
-   //             token::to_string(&token_and_span.tok).len() as i32,
+		pprust::token_to_string(&token_and_span.tok).len() as i32,
             _ => 0
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -59,7 +59,7 @@ pub fn main() {
                 let formatter = Formatter::new(out_tokens.as_slice(), &mut stdout);
                 formatter.process();
             },
-            Err(e) => fail!("Error in transformer: {}", e)
+            Err(e) => panic!("Error in transformer: {}", e)
         }
     }
 }

--- a/src/test.rs
+++ b/src/test.rs
@@ -43,7 +43,7 @@ fn test_rustfmt(source: &str) -> String {
                 let formatter = Formatter::new(out_tokens.as_slice(), &mut output);
                 formatter.process();
             },
-            Err(e) => fail!("Error in trasformer: {}", e)
+            Err(e) => panic!("Error in trasformer: {}", e)
         }
     }
     str::from_utf8(output.unwrap().as_slice()).unwrap().to_string()
@@ -148,12 +148,12 @@ pub fn main() {
             match formatter.next_token() {
                 Ok(true) => {
                     match formatter.parse_production() {
-                        Err(e) => fail!(e),
+                        Err(e) => panic!(e),
                         _ => {}
                     }
                 },
                 Ok(false) => break,
-                Err(e) => fail!(e)
+                Err(e) => panic!(e)
             }
         }
     }

--- a/src/token.rs
+++ b/src/token.rs
@@ -22,7 +22,7 @@
 
 use syntax::diagnostic::SpanHandler;
 use syntax::parse::lexer::{StringReader, TokenAndSpan, Reader};
-use syntax::parse::token::Token;
+use syntax::parse::token;
 
 use self::TransformedToken::{LexerVal, BlankLine, Comment};
 
@@ -38,7 +38,7 @@ impl TransformedToken {
         match self {
             &BlankLine => true,
             &LexerVal(ref t) => {
-                if t.tok == Token::Whitespace {
+                if t.tok == token::Whitespace {
                     let comment_str = sh.cm.span_to_snippet(t.sp).unwrap();
                     comment_str.as_slice().contains("\n")
                 } else {
@@ -54,7 +54,7 @@ pub fn extract_tokens(lexer: &mut StringReader) -> Vec<TransformedToken> {
     let mut in_toknspans = Vec::new();
     loop {
         match lexer.next_token() {
-            t @ TokenAndSpan{tok: Token::Eof, sp: _} => {
+            t @ TokenAndSpan{tok: token::Eof, sp: _} => {
                 in_toknspans.push(LexerVal(t));
                 break;
             },

--- a/src/token.rs
+++ b/src/token.rs
@@ -22,7 +22,9 @@
 
 use syntax::diagnostic::SpanHandler;
 use syntax::parse::lexer::{StringReader, TokenAndSpan, Reader};
-use syntax::parse::token;
+use syntax::parse::token::Token;
+
+use self::TransformedToken::{LexerVal, BlankLine, Comment};
 
 #[deriving(Clone)]
 pub enum TransformedToken {
@@ -36,7 +38,7 @@ impl TransformedToken {
         match self {
             &BlankLine => true,
             &LexerVal(ref t) => {
-                if t.tok == token::WS {
+                if t.tok == Token::Whitespace {
                     let comment_str = sh.cm.span_to_snippet(t.sp).unwrap();
                     comment_str.as_slice().contains("\n")
                 } else {
@@ -52,7 +54,7 @@ pub fn extract_tokens(lexer: &mut StringReader) -> Vec<TransformedToken> {
     let mut in_toknspans = Vec::new();
     loop {
         match lexer.next_token() {
-            t @ TokenAndSpan{tok: token::EOF, sp: _} => {
+            t @ TokenAndSpan{tok: Token::Eof, sp: _} => {
                 in_toknspans.push(LexerVal(t));
                 break;
             },

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -23,6 +23,7 @@
 use syntax::diagnostic::SpanHandler;
 use syntax::parse::lexer::{TokenAndSpan};
 use syntax::parse::token;
+use syntax::parse::token::Token;
 
 use token::TransformedToken;
 use token::TransformedToken::{Comment, LexerVal, BlankLine};
@@ -51,14 +52,14 @@ pub fn transform_tokens(input_tokens: &[TransformedToken], span_handler: &SpanHa
         match current_token {
             &LexerVal(ref current_token) => {
                 match current_token {
-                    t @ &TokenAndSpan { tok: token::WS, sp: _ } => {
+                    t @ &TokenAndSpan { tok: Token::Whitespace, sp: _ } => {
                         let ws_str = span_handler.cm.span_to_snippet(t.sp).unwrap();
                         if has_blank_line(ws_str.as_slice()) {
                             out_tokens.push(BlankLine);
                         }
                         curr_idx += 1;
                     },
-                    t @ &TokenAndSpan { tok: token::COMMENT, sp: _ } => {
+                    t @ &TokenAndSpan { tok: Token::Comment, sp: _ } => {
                         handle_comment(input_tokens, &mut out_tokens, &mut curr_idx, span_handler, t);
                     }
                     t => {

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -22,7 +22,7 @@
 
 use syntax::diagnostic::SpanHandler;
 use syntax::parse::lexer::{TokenAndSpan};
-use syntax::parse::token::Token;
+use syntax::parse::token;
 
 use token::TransformedToken;
 use token::TransformedToken::{Comment, LexerVal, BlankLine};
@@ -51,14 +51,14 @@ pub fn transform_tokens(input_tokens: &[TransformedToken], span_handler: &SpanHa
         match current_token {
             &LexerVal(ref current_token) => {
                 match current_token {
-                    t @ &TokenAndSpan { tok: Token::Whitespace, sp: _ } => {
+                    t @ &TokenAndSpan { tok: token::Whitespace, sp: _ } => {
                         let ws_str = span_handler.cm.span_to_snippet(t.sp).unwrap();
                         if has_blank_line(ws_str.as_slice()) {
                             out_tokens.push(BlankLine);
                         }
                         curr_idx += 1;
                     },
-                    t @ &TokenAndSpan { tok: Token::Comment, sp: _ } => {
+                    t @ &TokenAndSpan { tok: token::Comment, sp: _ } => {
                         handle_comment(input_tokens, &mut out_tokens, &mut curr_idx, span_handler, t);
                     }
                     t => {

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -22,7 +22,6 @@
 
 use syntax::diagnostic::SpanHandler;
 use syntax::parse::lexer::{TokenAndSpan};
-use syntax::parse::token;
 use syntax::parse::token::Token;
 
 use token::TransformedToken;

--- a/src/transform.rs
+++ b/src/transform.rs
@@ -24,13 +24,14 @@ use syntax::diagnostic::SpanHandler;
 use syntax::parse::lexer::{TokenAndSpan};
 use syntax::parse::token;
 
-use token::{Comment, LexerVal, BlankLine, TransformedToken};
+use token::TransformedToken;
+use token::TransformedToken::{Comment, LexerVal, BlankLine};
 
 pub type TransformerResult<T> = Result<T, String>;
 
 #[allow(dead_code)]
 pub fn has_blank_line<'a>(ws_str: &'a str) -> bool {
-    use std::str::StrSlice;
+    use std::str::Str;
     let newlines: Vec<(uint, uint)> = ws_str.match_indices("\n").collect();
     let newline_count = newlines.len();
     newline_count > 1


### PR DESCRIPTION
I don't know if you're maintaining this package any longer, but these changesets makes `rustfmt` compile under the latest version of Rust (0.13.0-dev). Most of the issues were due to namespacing of enums and some were functionality that had been moved elsewhere.

Also rename `fail!` to `panic!`.
